### PR TITLE
Fix CP Unit Tests

### DIFF
--- a/unittest/tensor_cp_test.cc
+++ b/unittest/tensor_cp_test.cc
@@ -82,13 +82,13 @@ TEST_CASE("CP")
       conv.set_norm(norm3);
       double diff =
               A1.compute_rank(5, conv, 1, false, 0, 100, false, false, true);
-      CHECK((diff - results(0,0)) <= epsilon);
+      CHECK(std::abs(diff - results(0,0)) <= epsilon);
     }
     SECTION("ALS MODE = 3, Finite error"){
       CP_ALS<tensor, conv_class> A1(D3);
       conv.set_norm(norm3);
       double diff = A1.compute_error(conv, 1e-2, 1, 100);
-      CHECK((diff - results(1,0)) <= epsilon);
+      CHECK(std::abs(diff - results(1,0)) <= epsilon);
     }
     SECTION("ALS MODE = 3, Tucker + CP"){
       auto d = D3;
@@ -96,7 +96,7 @@ TEST_CASE("CP")
       conv.set_norm(norm3);
       double diff =
               A1.compress_compute_tucker(0.1, conv, 5, true, false, 100, true);
-      CHECK((diff - results(2,0)) <= epsilon);
+      CHECK(std::abs(diff - results(2,0)) <= epsilon);
     }
     SECTION("ALS MODE = 3, Random + CP"){
       auto d = D3;
@@ -104,7 +104,7 @@ TEST_CASE("CP")
       conv.set_norm(norm3);
       double diff =
               A1.compress_compute_rand(2, conv, 0, 2, 5, true, false, 100, true);
-      CHECK((diff - results(3,0)) <= epsilon);
+      CHECK(std::abs(diff - results(3,0)) <= epsilon);
     }
 
     SECTION("ALS MODE = 4, Finite rank"){
@@ -112,53 +112,53 @@ TEST_CASE("CP")
       conv.set_norm(norm4);
       double diff =
               A1.compute_rank(5, conv);
-      CHECK((diff - results(4,0)) <= epsilon);
+      CHECK(std::abs(diff - results(4,0)) <= epsilon);
     }
     SECTION("ALS MODE = 4, Finite error"){
       CP_ALS<tensor, conv_class> A1(D4);
       conv.set_norm(norm4);
       double diff = A1.compute_error(conv, 1e-2, 1, 100);
-      CHECK((diff - results(5,0)) <= epsilon);
+      CHECK(std::abs(diff - results(5,0)) <= epsilon);
     }
     SECTION("ALS MODE = 4, Tucker + CP"){
       auto d = D4;
       CP_ALS<tensor, conv_class> A1(d);
       conv.set_norm(norm4);
       double diff = A1.compress_compute_tucker(0.1, conv, 5, true, false, 1e4, true);
-      CHECK((diff - results(6,0)) <= epsilon);
+      CHECK(std::abs(diff - results(6,0)) <= epsilon);
     }
     SECTION("ALS MODE = 4, Random + CP"){
       auto d = D4;
       CP_ALS<tensor, conv_class> A1(d);
       conv.set_norm(norm4);
       double diff = A1.compress_compute_rand(3, conv, 0, 2, 1, true, false, 20, true);
-      CHECK((diff - results(7,0)) <= epsilon);
+      CHECK(std::abs(diff - results(7,0)) <= epsilon);
     }
     SECTION("ALS MODE = 5, Finite rank"){
       CP_ALS<tensor, conv_class> A1(D5);
       conv.set_norm(norm5);
       double diff = A1.compute_rank(5, conv);
-      CHECK((diff - results(8,0)) <= epsilon);
+      CHECK(std::abs(diff - results(8,0)) <= epsilon);
     }
      SECTION("ALS MODE = 5, Finite error"){
       CP_ALS<tensor, conv_class> A1(D5);
       conv.set_norm(norm5);
       double diff = A1.compute_error(conv, 1e-2, 10, 200);
-      CHECK((diff - results(9,0)) <= epsilon);
+      CHECK(std::abs(diff - results(9,0)) <= epsilon);
     }
     SECTION("ALS MODE = 5, Tucker + CP"){
       auto d = D5;
       CP_ALS<tensor, conv_class> A1(d);
       conv.set_norm(norm5);
       double diff = A1.compress_compute_tucker(0.1, conv, 5, true, false, 100, true);
-      CHECK((diff - results(10,0)) <= epsilon);
+      CHECK(std::abs(diff - results(10,0)) <= epsilon);
     }
     SECTION("ALS MODE = 5, Random + CP"){
       auto d = D5;
       CP_ALS<tensor, conv_class> A1(d);
       conv.set_norm(norm5);
       double diff = A1. compress_compute_rand(1, conv, 0, 2, 5, true, false, 100, false);
-      CHECK((diff - results(11,0)) <= epsilon);
+      CHECK(std::abs(diff - results(11,0)) <= epsilon);
     }
   }
   // RALS tests
@@ -168,13 +168,13 @@ TEST_CASE("CP")
       conv.set_norm(norm3);
       double diff =
               A1.compute_rank(5, conv, 1, false, 0, 100, false, false, true);
-      CHECK((diff - results(12,0)) <= epsilon);
+      CHECK(std::abs(diff - results(12,0)) <= epsilon);
     }
     SECTION("RALS MODE = 3, Finite error"){
       CP_RALS<tensor, conv_class> A1(D3);
       conv.set_norm(norm3);
       double diff = A1.compute_error(conv, 1e-2, 1, 100);
-      CHECK((diff - results(13,0)) <= epsilon);
+      CHECK(std::abs(diff - results(13,0)) <= epsilon);
     }
     SECTION("RALS MODE = 3, Tucker + CP"){
       auto d = D3;
@@ -182,7 +182,7 @@ TEST_CASE("CP")
       conv.set_norm(norm3);
       double diff =
               A1.compress_compute_tucker(0.1, conv, 5, true, false, 100, true);
-      CHECK((diff - results(14,0)) <= epsilon);
+      CHECK(std::abs(diff - results(14,0)) <= epsilon);
     }
     SECTION("RALS MODE = 3, Random + CP"){
       auto d = D3;
@@ -190,60 +190,60 @@ TEST_CASE("CP")
       conv.set_norm(norm3);
       double diff =
               A1.compress_compute_rand(2, conv, 0, 2, 5, true, false, 100, true);
-      CHECK((diff - results(15,0)) <= epsilon);
+      CHECK(std::abs(diff - results(15,0)) <= epsilon);
     }
     SECTION("RALS MODE = 4, Finite rank"){
       CP_RALS<tensor, conv_class> A1(D4);
       conv.set_norm(norm4);
       double diff =
               A1.compute_rank(5, conv);
-      CHECK((diff - results(16,0)) <= epsilon);
+      CHECK(std::abs(diff - results(16,0)) <= epsilon);
     }
     SECTION("RALS MODE = 4, Finite error"){
       CP_RALS<tensor, conv_class> A1(D4);
       conv.set_norm(norm4);
       double diff = A1.compute_error(conv, 1e-2, 1, 100);
-      CHECK((diff - results(17,0)) <= epsilon);
+      CHECK(std::abs(diff - results(17,0)) <= epsilon);
     }
     SECTION("RALS MODE = 4, Tucker + CP"){
       auto d = D4;
       CP_RALS<tensor, conv_class> A1(d);
       conv.set_norm(norm4);
       double diff = A1.compress_compute_tucker(0.1, conv, 5, true, false, 100, true);
-      CHECK((diff - results(18,0)) <= epsilon);
+      CHECK(std::abs(diff - results(18,0)) <= epsilon);
     }
     SECTION("RALS MODE = 4, Random + CP"){
       auto d = D4;
       CP_RALS<tensor, conv_class> A1(d);
       conv.set_norm(norm4);
       double diff = A1.compress_compute_rand(3, conv, 0, 2, 1, true, false, 20, true);
-      CHECK((diff - results(19,0)) <= epsilon);
+      CHECK(std::abs(diff - results(19,0)) <= epsilon);
     }
     SECTION("RALS MODE = 5, Finite rank"){
       CP_RALS<tensor, conv_class> A1(D5);
       conv.set_norm(norm5);
       double diff = A1.compute_rank(5, conv);
-      CHECK((diff - results(20,0)) <= epsilon);
+      CHECK(std::abs(diff - results(20,0)) <= epsilon);
     }
     SECTION("RALS MODE = 5, Finite error"){
       CP_RALS<tensor, conv_class> A1(D5);
       conv.set_norm(norm5);
       double diff = A1.compute_error(conv, 1e-2, 1, 20);
-      CHECK((diff - results(21,0)) <= epsilon);
+      CHECK(std::abs(diff - results(21,0)) <= epsilon);
     }
     SECTION("RALS MODE = 5, Tucker + CP"){
       auto d = D5;
       CP_RALS<tensor, conv_class> A1(d);
       conv.set_norm(norm5);
       double diff = A1.compress_compute_tucker(0.1, conv, 5, true, false, 100, true);
-      CHECK((diff - results(22,0)) <= epsilon);
+      CHECK(std::abs(diff - results(22,0)) <= epsilon);
     }
     SECTION("RALS MODE = 5, Random + CP"){
       auto d = D5;
       CP_RALS<tensor, conv_class> A1(d);
       conv.set_norm(norm5);
       double diff = A1.compress_compute_rand(1, conv, 0, 2, 5, true, false, 100, true);
-      CHECK((diff - results(23,0)) <= epsilon);
+      CHECK(std::abs(diff - results(23,0)) <= epsilon);
     }
   }
   // CP-DF-ALS tests
@@ -252,37 +252,37 @@ TEST_CASE("CP")
       CP_DF_ALS<tensor, conv_class> A1(D3, D3);
       conv.set_norm(norm32);
       double diff = A1.compute_rank(5, conv);
-      CHECK((diff - results(24,0)) <= epsilon);
+      CHECK(std::abs(diff - results(24,0)) <= epsilon);
     }
      SECTION("DF-ALS MODE = 3, Finite error"){
       CP_DF_ALS<tensor, conv_class> A1(D3, D3);
       conv.set_norm(norm32);
       double diff = A1.compute_error(conv, 1e-2, 1, 20);
-      CHECK((diff - results(25,0)) <= epsilon);
+      CHECK(std::abs(diff - results(25,0)) <= epsilon);
     }
      SECTION("DF-ALS MODE = 4, Finite rank"){
       CP_DF_ALS<tensor,conv_class> A1(D4,D4);
       conv.set_norm(norm42);
       double diff = A1.compute_rank(5,conv);
-      CHECK((diff - results(26,0)) <= epsilon);
+      CHECK(std::abs(diff - results(26,0)) <= epsilon);
     }
     SECTION("DF-ALS MODE = 4, Finite error"){
       CP_DF_ALS<tensor,conv_class>A1(D4,D4);
       conv.set_norm(norm42);
       double diff = A1.compute_error(conv, 1e-2, 1, 20);
-      CHECK((diff - results(27,0)) <= epsilon);
+      CHECK(std::abs(diff - results(27,0)) <= epsilon);
     }
     SECTION("DF-ALS MODE = 5, Finite rank"){
       CP_DF_ALS<tensor,conv_class> A1(D5,D5);
       conv.set_norm(norm52);
       double diff = A1.compute_rank(5,conv);
-      CHECK((diff - results(28,0)) <= epsilon);
+      CHECK(std::abs(diff - results(28,0)) <= epsilon);
     }
     SECTION("DF-ALS MODE = 5, Finite error"){
       CP_DF_ALS<tensor,conv_class>A1(D5,D5);
       conv.set_norm(norm52);
       double diff = A1.compute_error(conv, 1e-2, 1, 20);
-      CHECK((diff - results(29,0)) <= epsilon);
+      CHECK(std::abs(diff - results(29,0)) <= epsilon);
     }
   }
   // coupled ALS test
@@ -292,42 +292,42 @@ TEST_CASE("CP")
       COUPLED_CP_ALS<tensor, conv_class_coupled> A1(D3, D3);
       conv_coupled.set_norm(norm3, norm3);
       double diff = A1.compute_rank(5, conv_coupled);
-      CHECK((diff - results(30,0)) <= epsilon);
+      CHECK(std::abs(diff - results(30,0)) <= epsilon);
     }
     SECTION("COUPLED-ALS MODE = 3, Finite error"){
       conv_class_coupled conv_coupled(3, 1e-3);
       COUPLED_CP_ALS<tensor, conv_class_coupled> A1(D3, D3);
       conv_coupled.set_norm(norm3, norm3);
       double diff = A1.compute_error(conv_coupled, 1e-2, 1, 20);
-      CHECK((diff - results(31,0)) <= epsilon);
+      CHECK(std::abs(diff - results(31,0)) <= epsilon);
     }
     SECTION("COUPLED-ALS MODE = 4, Finite rank"){
       conv_class_coupled conv_coupled(4, 1e-3);
       COUPLED_CP_ALS<tensor, conv_class_coupled> A1(D4, D4);
       conv_coupled.set_norm(norm4, norm4);
       double diff = A1.compute_rank(5,conv_coupled);
-      CHECK((diff - results(32,0)) <= epsilon);
+      CHECK(std::abs(diff - results(32,0)) <= epsilon);
     }
     SECTION("COUPLED-ALS MODE = 4, Finite error"){
       conv_class_coupled conv_coupled(4, 1e-3);
       COUPLED_CP_ALS<tensor, conv_class_coupled> A1(D4, D4);
       conv_coupled.set_norm(norm4, norm4);
       double diff = A1.compute_error(conv_coupled, 1e-2, 1, 20);
-      CHECK((diff - results(33,0)) <= epsilon);
+      CHECK(std::abs(diff - results(33,0)) <= epsilon);
     }
     SECTION("COUPLED-ALS MODE = 5, Finite rank"){
       conv_class_coupled conv_coupled(5, 1e-3);
       COUPLED_CP_ALS<tensor, conv_class_coupled> A1(D5, D5);
       conv_coupled.set_norm(norm5, norm5);
       double diff = A1.compute_rank(5,conv_coupled);
-      CHECK((diff - results(34,0)) <= epsilon);
+      CHECK(std::abs(diff - results(34,0)) <= epsilon);
     }
     SECTION("COUPLED-ALS MODE = 5, Finite error"){
       conv_class_coupled conv_coupled(5, 1e-3);
       COUPLED_CP_ALS<tensor, conv_class_coupled> A1(D5, D5);
       conv_coupled.set_norm(norm5, norm5);
       double diff = A1.compute_error(conv_coupled, 1e-2, 1, 20);
-      CHECK((diff - results(35,0)) <= epsilon);
+      CHECK(std::abs(diff - results(35,0)) <= epsilon);
     }
   }
 }


### PR DESCRIPTION
Changes difference checks in CP units tests to be absolute: exposes false test passes (#111)