### PR TITLE
only introduce c++20 extensions if compiler provides c++17 std

### DIFF
--- a/btas/type_traits.h
+++ b/btas/type_traits.h
@@ -5,7 +5,7 @@
 #include <complex>
 
 // C++20 extensions
-#if __cplusplus < 202002L
+#if __cplusplus <= 201703L
 namespace std {
   template< class T >
   struct remove_cvref {


### PR DESCRIPTION
some compilers provide intermediate values for `__cplusplus`, so strengthen the check for pre-C++20 to mean C++17 or older