### PR TITLE
fixes for FetchContent'ing Boost

### DIFF
--- a/cmake/modules/FindOrFetchBoost.cmake
+++ b/cmake/modules/FindOrFetchBoost.cmake
@@ -16,12 +16,6 @@ if (NOT TARGET Boost::boost)
   # boost-cmake/install_rules https://github.com/Orphis/boost-cmake/pull/45 is supposed to fix it but is inactive
   message(WARNING "Building Boost from source makes BTAS unusable from the install location! Install Boost using package manager or manually and reconfigure/reinstall BTAS to fix this")
   install(TARGETS Boost_serialization EXPORT btas COMPONENT boost-libs)
-  export(EXPORT btas
-      FILE "${PROJECT_BINARY_DIR}/boost-targets.cmake")
-  install(EXPORT btas
-      FILE "boost-targets.cmake"
-      DESTINATION "${BTAS_INSTALL_CMAKEDIR}"
-      COMPONENT boost-libs)
 
 endif(NOT TARGET Boost::boost)
 

--- a/external/boost.cmake
+++ b/external/boost.cmake
@@ -46,9 +46,11 @@ if (NOT TARGET Boost::boost OR NOT TARGET Boost::serialization)
 endif (NOT TARGET Boost::boost OR NOT TARGET Boost::serialization)
 
 # if Boost not found, and BTAS_BUILD_DEPS_FROM_SOURCE=ON, use FetchContent to build it
+set(BTAS_BUILT_BOOST_FROM_SOURCE 0)
 if (NOT TARGET Boost::boost)
   if (BTAS_BUILD_DEPS_FROM_SOURCE)
-    include(FindOrFetchBoost)
+    include(${PROJECT_SOURCE_DIR}/cmake/modules/FindOrFetchBoost.cmake)
+    set(BTAS_BUILT_BOOST_FROM_SOURCE 1)
   else(BTAS_BUILD_DEPS_FROM_SOURCE)
     message(FATAL_ERROR "Boost is a required prerequisite of BTAS, but not found; install Boost or set BTAS_BUILD_DEPS_FROM_SOURCE=ON to obtain from source")
   endif(BTAS_BUILD_DEPS_FROM_SOURCE)

--- a/external/linalgpp.cmake
+++ b/external/linalgpp.cmake
@@ -1,9 +1,9 @@
 # import BLAS++ / LAPACK++
 if (ENABLE_WFN91_LINALG_DISCOVERY_KIT)
-    include(FetchWfn91LinAlgModules)
-    include(FindLinalg)
+    include(${vg_cmake_kit_SOURCE_DIR}/modules/FetchWfn91LinAlgModules.cmake)
+    include(${vg_cmake_kit_SOURCE_DIR}/modules/FindLinalg.cmake)
 endif(ENABLE_WFN91_LINALG_DISCOVERY_KIT)
-include(FindOrFetchLinalgPP)
+include(${vg_cmake_kit_SOURCE_DIR}/modules/FindOrFetchLinalgPP.cmake)
 target_link_libraries(BTAS INTERFACE blaspp lapackpp)
 if (TARGET blaspp_headers)
     target_link_libraries(BTAS INTERFACE blaspp_headers)


### PR DESCRIPTION
- boost.cmake should use its own FindOrFetchBoost
- no need to duplicate export btas in boost-targets