### PR TITLE
Fix default is_index

### DIFF
--- a/btas/index_traits.h
+++ b/btas/index_traits.h
@@ -26,7 +26,7 @@ public:
 /// test _Index conforms the TWG.Index concept
 /// check only value_type and operator[]
 template<typename ...>
-class is_index;
+class is_index : public std::false_type {};
 
 template<typename _Index>
 class is_index<_Index> {


### PR DESCRIPTION
For type traits that are inferring characteristics of type(s), the default needs some kind of implementation. Otherwise you can get compile errors due to incomplete types.