### PR TITLE
Remove redundant order trait.

### DIFF
--- a/btas/tensor_traits.h
+++ b/btas/tensor_traits.h
@@ -83,15 +83,8 @@ public:
 
 /// checks _Tensor meets the TWG.BoxTensor concept requirements
 template<class _Tensor>
-class boxtensor_storage_order {
-public:
-   enum {row_major = boxrange_iteration_order<typename _Tensor::range_type>::row_major,
-         other = boxrange_iteration_order<typename _Tensor::range_type>::other,
-         column_major = boxrange_iteration_order<typename _Tensor::range_type>::column_major
-   };
-   static constexpr const int
-   value = boxrange_iteration_order<typename _Tensor::range_type>::value;
-};
+class boxtensor_storage_order : public boxrange_iteration_order<typename _Tensor::range_type> {};
+
 
 } // namespace btas
 


### PR DESCRIPTION
`boxtensor_storage_order` and `boxrange_iteration_order` implementations are identical. Combine the definitions to eliminate redundant code.